### PR TITLE
2021 edition, formatting, clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["reinforcement", "q", "learning"]
 categories = ["science", "algorithms"]
 license = "MPL-2.0"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "milanboers/rurel", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Rurel is a flexible, reusable reinforcement learning (Q learning) implementation
 * [Release documentation](https://docs.rs/rurel)
 
 In Cargo.toml:
-```
+```toml
 rurel = "0.2.0"
 ```
 
 
 An example is included. This teaches an agent on a 21x21 grid how to arrive at 10,10, using actions (go left, go up, go right, go down):
-```
+```console
 cargo run --example eucdist
 ```
 
@@ -31,7 +31,7 @@ Let's implement the example in `cargo run --example eucdist`. We want to make an
 
 First, let's define a `State`, which should represent a position on a 21x21, and the correspoding Action, which is either up, down, left or right.
 
-```rust
+```rust,igonre
 use rurel::mdp::State;
 
 #[derive(PartialEq, Eq, Hash, Clone)]
@@ -57,7 +57,7 @@ impl State for MyState {
 
 Then define the agent:
 
-```rust
+```rust, ignore
 use rurel::mdp::Agent;
 
 struct MyAgent { state: MyState }
@@ -80,7 +80,7 @@ impl Agent<MyState> for MyAgent {
 
 That's all. Now make a trainer and train the agent with Q learning, with learning rate 0.2, discount factor 0.01 and an initial value of Q of 2.0. We let the trainer run for 100000 iterations, randomly exploring new states.
 
-```rust
+```rust, ignore
 use rurel::AgentTrainer;
 use rurel::strategy::learn::QLearning;
 use rurel::strategy::explore::RandomExploration;
@@ -96,6 +96,9 @@ trainer.train(&mut agent,
 
 After this, you can query the learned value (Q) for a certain action in a certain state by:
 
-```rust
+```rust, ignore
 trainer.expected_value(&state, &action) // : Option<f64>
 ```
+
+## Development
+* Run `cargo +nightly fmt` to format the code.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+reorder_impl_items = true

--- a/src/examples/eucdist.rs
+++ b/src/examples/eucdist.rs
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate rand;
-extern crate rurel;
-
 use std::collections::HashMap;
 
 use rurel::mdp::{Agent, State};
@@ -28,11 +25,13 @@ enum MyAction {
 
 impl State for MyState {
     type A = MyAction;
+
     fn reward(&self) -> f64 {
         let (tx, ty) = (10, 10);
         let d = (((tx - self.x).pow(2) + (ty - self.y).pow(2)) as f64).sqrt();
         -d
     }
+
     fn actions(&self) -> Vec<MyAction> {
         vec![
             MyAction::Move { dx: -1, dy: 0 },
@@ -51,7 +50,8 @@ impl Agent<MyState> for MyAgent {
     fn current_state(&self) -> &MyState {
         &self.state
     }
-    fn take_action(&mut self, action: &MyAction) -> () {
+
+    fn take_action(&mut self, action: &MyAction) {
         match action {
             &MyAction::Move { dx, dy } => {
                 self.state = MyState {
@@ -93,7 +93,7 @@ fn main() {
                 })
                 .unwrap();
             let val: f64 = entry.values().sum();
-            print!("{:.3}\t", val);
+            print!("{val:.3}\t");
         }
         println!();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,14 +77,20 @@
 //!     > trainer.expected_value(&test_state, &go_up));
 //! ```
 
-pub mod mdp;
-pub mod strategy;
+// Run tests in the readme, but don't include readme in the documentation.
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod doc_test {}
+
+use std::collections::HashMap;
 
 use mdp::{Agent, State};
-use std::collections::HashMap;
 use strategy::explore::ExplorationStrategy;
 use strategy::learn::LearningStrategy;
 use strategy::terminate::TerminationStrategy;
+
+pub mod mdp;
+pub mod strategy;
 
 /// An `AgentTrainer` can be trained for using a certain [Agent](mdp/trait.Agent.html). After
 /// training, the `AgentTrainer` contains learned knowledge about the process, and can be queried
@@ -104,25 +110,30 @@ where
     pub fn new() -> AgentTrainer<S> {
         AgentTrainer { q: HashMap::new() }
     }
+
     /// Fetches the learned values for the given state, by `Action`, or `None` if no value was
     /// learned.
     pub fn expected_values(&self, state: &S) -> Option<&HashMap<S::A, f64>> {
         // XXX: make associated const with empty map and remove Option?
         self.q.get(state)
     }
+
     /// Fetches the learned value for the given `Action` in the given `State`, or `None` if no
     /// value was learned.
     pub fn expected_value(&self, state: &S, action: &S::A) -> Option<f64> {
         self.q.get(state).and_then(|m| m.get(action).copied())
     }
+
     /// Returns a clone of the entire learned state to be saved or used elsewhere.
     pub fn export_learned_values(&self) -> HashMap<S, HashMap<S::A, f64>> {
         self.q.clone()
     }
+
     /// Imports a state, completely replacing any learned progress
     pub fn import_state(&mut self, q: HashMap<S, HashMap<S::A, f64>>) {
         self.q = q;
     }
+
     /// Returns the best action for the given `State`, or `None` if no values were learned.
     pub fn best_action(&self, state: &S) -> Option<S::A> {
         self.expected_values(state)
@@ -132,6 +143,7 @@ where
             })
             .map(|t| t.0.clone())
     }
+
     /// Trains this [AgentTrainer] using the given [ExplorationStrategy], [LearningStrategy] and
     /// [Agent] until the [TerminationStrategy] decides to stop.
     pub fn train(
@@ -159,14 +171,14 @@ where
                 .or_insert_with(HashMap::new)
                 .insert(action, v);
 
-            if termination_strategy.should_stop(&s_t_next) {
+            if termination_strategy.should_stop(s_t_next) {
                 break;
             }
         }
     }
 }
 
-impl<S: mdp::State> Default for AgentTrainer<S> {
+impl<S: State> Default for AgentTrainer<S> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/mdp/mod.rs
+++ b/src/mdp/mod.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate rand;
-
 use std::hash::Hash;
 
 /// A `State` is something which has a reward, and has a certain set of actions associated with it.

--- a/src/strategy/explore/mod.rs
+++ b/src/strategy/explore/mod.rs
@@ -4,11 +4,10 @@
 
 //! Module containing exploration strategies.
 
-pub mod random;
-
 pub use self::random::RandomExploration;
+use crate::mdp::{Agent, State};
 
-use mdp::{Agent, State};
+pub mod random;
 
 /// Trait for exploration strategies. An exploration strategy decides, based on an `Agent`, which
 /// action to take next.

--- a/src/strategy/explore/random.rs
+++ b/src/strategy/explore/random.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use mdp::{Agent, State};
-use strategy::explore::ExplorationStrategy;
+use crate::mdp::{Agent, State};
+use crate::strategy::explore::ExplorationStrategy;
 
 /// The random exploration strategy. This strategy always takes a random action, as defined for the
 /// Agent by

--- a/src/strategy/learn/mod.rs
+++ b/src/strategy/learn/mod.rs
@@ -4,12 +4,12 @@
 
 //! Module containing learning (value updating) strategies.
 
-pub mod q;
+use std::collections::HashMap;
 
 pub use self::q::QLearning;
+use crate::mdp::State;
 
-use mdp::State;
-use std::collections::HashMap;
+pub mod q;
 
 /// A learning strategy can calculate a learned value for the action which was taken from the
 /// values for the actions in the new state (`new_action_values`), the current value

--- a/src/strategy/learn/q.rs
+++ b/src/strategy/learn/q.rs
@@ -4,9 +4,10 @@
 
 //! Module for the Q Learning strategy.
 
-use mdp::State;
 use std::collections::HashMap;
-use strategy::learn::LearningStrategy;
+
+use crate::mdp::State;
+use crate::strategy::learn::LearningStrategy;
 
 /// The Q Learning strategy
 pub struct QLearning {

--- a/src/strategy/terminate/fixed_iterations.rs
+++ b/src/strategy/terminate/fixed_iterations.rs
@@ -4,8 +4,8 @@
 
 //! Module for the fixed iterations strategy.
 
-use mdp::State;
-use strategy::terminate::TerminationStrategy;
+use crate::mdp::State;
+use crate::strategy::terminate::TerminationStrategy;
 
 /// The termination strategy that ends after a certain number of iterations, regardless of the
 /// `State`.

--- a/src/strategy/terminate/mod.rs
+++ b/src/strategy/terminate/mod.rs
@@ -4,11 +4,10 @@
 
 //! Module containing termination strategies.
 
-pub mod fixed_iterations;
-
 pub use self::fixed_iterations::FixedIterations;
+use crate::mdp::State;
 
-use mdp::State;
+pub mod fixed_iterations;
 
 /// A termination strategy decides when to end training.
 pub trait TerminationStrategy<S: State> {


### PR DESCRIPTION
I did a rough pass over the code while attempting to understanding it. Let me know if these changes are ok.

* use nightly `cargo +nightly fmt` to optimize and sort use statements
* used clippy to fix a few minor things
* removed externs - not needed with 2021 edition
* added readme to the doctest (they all fail, but at least they are now part of the test code and can be improved in a another PR)