### PR TITLE
Implementing serde for AgentTrainer and methods for JSON save/load. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,13 @@ travis-ci = { repository = "milanboers/rurel", branch = "master" }
 
 [dependencies]
 rand = "0.8"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "*"
 
 [[example]]
 name = "eucdist"
 path = "src/examples/eucdist.rs"
+
+[[example]]
+name = "save_load"
+path = "src/examples/save_load.rs"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ First, let's define a `State`, which should represent a position on a 21x21, and
 ```rust
 use rurel::mdp::State;
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct MyState { x: i32, y: i32 }
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct MyAction { dx: i32, dy: i32 }
 
 impl State for MyState {
@@ -98,6 +98,32 @@ After this, you can query the learned value (Q) for a certain action in a certai
 
 ```rust, ignore
 trainer.expected_value(&state, &action) // : Option<f64>
+```
+
+AgentTrainer implements serialize from serde, so you can convert it into a file. AgentTrainer also has methods for doing this automatically. See the save_load example for more details. 
+```rust, ignore
+use rurel::AgentTrainer;
+use rurel::strategy::learn::QLearning;
+use rurel::strategy::explore::RandomExploration;
+use rurel::strategy::terminate::FixedIterations;
+
+// Create the trainer object. 
+let mut trainer = AgentTrainer::new();
+// import data from the previous training session into the agent. 
+trainer.import_state_from_json("data/grid.json");   // <-- Import data from JSON
+// Set the agents starting state. 
+let mut agent = MyAgent { state: MyState { x: 0, y: 0 }};
+
+// Training configuration
+trainer.train(
+    &mut agent,
+    &QLearning::new(0.2, 0.01, 2.),
+    &mut FixedIterations::new(0),
+    &RandomExploration::new()
+);
+
+// Export learned values to specified JSON file. 
+trainer.export_learned_values_to_json("data/grid.json"); // <-- Export data to JSON
 ```
 
 ## Development

--- a/src/examples/eucdist.rs
+++ b/src/examples/eucdist.rs
@@ -8,9 +8,9 @@ use rurel::mdp::{Agent, State};
 use rurel::strategy::explore::RandomExploration;
 use rurel::strategy::learn::QLearning;
 use rurel::strategy::terminate::FixedIterations;
-use rurel::AgentTrainer;
+use rurel::{AgentTrainer, *};
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct MyState {
     x: i32,
     y: i32,
@@ -18,7 +18,7 @@ struct MyState {
     maxy: i32,
 }
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 enum MyAction {
     Move { dx: i32, dy: i32 },
 }

--- a/src/examples/save_load.rs
+++ b/src/examples/save_load.rs
@@ -1,0 +1,107 @@
+use rurel::mdp::*;
+use rurel::strategy::explore::RandomExploration;
+use rurel::strategy::learn::QLearning;
+use rurel::strategy::terminate::FixedIterations;
+use rurel::*;
+
+// MyState and MyAction implement Serialize and Deserialize so that the data can be saved to JSON or any other file type.
+
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct MyState {
+    x: i32,
+    y: i32,
+}
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct MyAction {
+    dx: i32,
+    dy: i32,
+}
+
+impl State for MyState {
+    type A = MyAction;
+
+    fn reward(&self) -> f64 {
+        // Negative Euclidean distance
+        -((((10 - self.x).pow(2) + (10 - self.y).pow(2)) as f64).sqrt())
+    }
+
+    fn actions(&self) -> Vec<MyAction> {
+        vec![
+            MyAction { dx: 0, dy: -1 }, // up
+            MyAction { dx: 0, dy: 1 },  // down
+            MyAction { dx: -1, dy: 0 }, // left
+            MyAction { dx: 1, dy: 0 },  // right
+        ]
+    }
+}
+
+struct MyAgent {
+    state: MyState,
+}
+impl Agent<MyState> for MyAgent {
+    fn current_state(&self) -> &MyState {
+        &self.state
+    }
+
+    fn take_action(&mut self, action: &MyAction) -> () {
+        match action {
+            &MyAction { dx, dy } => {
+                self.state = MyState {
+                    x: (((self.state.x + dx) % 21) + 21) % 21, // (x+dx) mod 21
+                    y: (((self.state.y + dy) % 21) + 21) % 21, // (y+dy) mod 21
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    // Creates a trainer and saves its data to a json
+    create_and_save();
+    // loads the json, trains some more, then saves to the json the new data.
+    load_and_save();
+}
+
+/// Create a new Agent with no learned values, train it, then save its data to a JSON file.
+fn create_and_save() {
+    // Create the trainer object
+    let mut trainer = AgentTrainer::new();
+    // Starting state of the Agent
+    let mut agent = MyAgent {
+        state: MyState { x: 0, y: 0 },
+    };
+
+    // Training configuration
+    trainer.train(
+        &mut agent,
+        &QLearning::new(0.2, 0.01, 2.),
+        &mut FixedIterations::new(100000),
+        &RandomExploration::new(),
+    );
+
+    // tell the trainer to export its learned values to the specified JSON file.
+    trainer.export_learned_values_to_json("grid.json");
+}
+
+/// Load existing data into an Agent to continue training, train it some more, then save its data to a JSON file.
+fn load_and_save() {
+    // Create the trainer object.
+    let mut trainer = AgentTrainer::new();
+    // import data from the previous training session into the agent.
+    trainer.import_state_from_json("grid.json");
+    // Set the agents starting state.
+    let mut agent = MyAgent {
+        state: MyState { x: 0, y: 0 },
+    };
+
+    // Training configuration
+    trainer.train(
+        &mut agent,
+        &QLearning::new(0.2, 0.01, 2.),
+        &mut FixedIterations::new(0),
+        &RandomExploration::new(),
+    );
+
+    // Export learned values to specified JSON file.
+    trainer.export_learned_values_to_json("grid.json");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,11 @@
 //!
 //! ```
 //! use rurel::mdp::{State, Agent};
+//! use rurel::*;
 //!
-//! #[derive(PartialEq, Eq, Hash, Clone)]
+//! #[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 //! struct MyState { x: i32, y: i32 }
-//! #[derive(PartialEq, Eq, Hash, Clone)]
+//! #[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 //! struct MyAction { dx: i32, dy: i32 }
 //!
 //! impl State for MyState {
@@ -83,8 +84,16 @@
 mod doc_test {}
 
 use std::collections::HashMap;
+use std::fs;
 
+// making serde available from this crate
+// serde is necessary to parse the created data into
+// a json file or some other serialized format
+pub extern crate serde;
 use mdp::{Agent, State};
+use serde::ser::SerializeSeq;
+pub use serde::{Deserialize, Serialize};
+
 use strategy::explore::ExplorationStrategy;
 use strategy::learn::LearningStrategy;
 use strategy::terminate::TerminationStrategy;
@@ -129,9 +138,51 @@ where
         self.q.clone()
     }
 
+    /// writes the data to the indicated JSON file
+    pub fn export_learned_values_to_json(&self, filepath: &str) {
+        use std::io::Write;
+        // Create / Overwrite file
+        let mut file = fs::File::create(filepath).expect("Failed to Create File!");
+        // write the serialized data to JSON then to the file
+        file.write_all(serde_json::to_string(&self).unwrap().as_bytes())
+            .expect("Failed to write json data to file");
+    }
+
     /// Imports a state, completely replacing any learned progress
     pub fn import_state(&mut self, q: HashMap<S, HashMap<S::A, f64>>) {
         self.q = q;
+    }
+
+    /// Imports a state from a JSON file, completely replacing any learned progress.  
+    pub fn import_state_from_json(&mut self, filepath: &str) {
+        // Get string from file
+        let contents =
+            std::fs::read_to_string("data/grid.json").expect("Failed to read file contents!");
+        // initialize data container
+        let mut data: HashMap<S, HashMap<S::A, f64>> = HashMap::new();
+
+        // if the contents are empty (no data exists), just begin with an empty hashmap
+        // Else, pull everything out of the file and put it into data.
+        if contents != "" {
+            // deserialize from vector data
+            let vec_data: Vec<(S, Vec<(S::A, f64)>)> =
+                serde_json::from_str(&contents).expect("Failed to parse JSON File!");
+            // temporary hashmap for holding inner data
+            let mut inner: HashMap<S::A, f64> = HashMap::new();
+            // iterate through the vector
+            for (state, actions) in vec_data.iter() {
+                // clear inner data so no duplicates
+                inner.clear();
+                for (a, r) in actions.iter() {
+                    // put data in inner
+                    inner.insert(a.clone(), r.clone());
+                }
+                // put state and inner in data
+                data.insert(state.clone(), inner.clone());
+            }
+        }
+
+        self.q = data;
     }
 
     /// Returns the best action for the given `State`, or `None` if no values were learned.
@@ -181,5 +232,41 @@ where
 impl<S: State> Default for AgentTrainer<S> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Added to serialize the data within AgentTrainer for saving and loading.
+impl<S> Serialize for AgentTrainer<S>
+where
+    S: State,
+{
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
+    where
+        SER: serde::Serializer,
+    {
+        // Container we want to convert self.q into
+        let mut vec_data: Vec<(S, Vec<(S::A, f64)>)> = Vec::with_capacity(self.q.len());
+        // temporary vector for holding inner data
+        let mut inner: Vec<(S::A, f64)> = Vec::new();
+        // Iterate over self.q
+        for (state, actions) in self.q.iter() {
+            // clear inner so there are no duplicates
+            inner.clear();
+            for (a, r) in actions.iter() {
+                // fill inner with necessary contents
+                inner.push((a.clone(), *r));
+            }
+            // fill vector data
+            vec_data.push((state.clone(), inner.clone()));
+        }
+
+        // initialize serializer as a sequence, which we can do now since it is a Vec
+        let mut seq = serializer.serialize_seq(Some(self.q.len()))?;
+        // iterate over vec data and serialize each element into the serializer
+        for e in vec_data.iter() {
+            seq.serialize_element(&e)?;
+        }
+        // end serialization
+        seq.end()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,11 @@ use std::fs;
 // serde is necessary to parse the created data into
 // a json file or some other serialized format
 pub extern crate serde;
-use mdp::{Agent, State};
-use serde::ser::SerializeSeq;
+// making de and se public so it can be accessed using rurel::*;
 pub use serde::{Deserialize, Serialize};
+use serde::ser::SerializeSeq;
 
+use mdp::{Agent, State};
 use strategy::explore::ExplorationStrategy;
 use strategy::learn::LearningStrategy;
 use strategy::terminate::TerminationStrategy;
@@ -142,7 +143,8 @@ where
     pub fn export_learned_values_to_json(&self, filepath: &str) {
         use std::io::Write;
         // Create / Overwrite file
-        let mut file = fs::File::create(filepath).expect("Failed to Create File!");
+        let mut file = fs::File::create(filepath)
+            .expect("Failed to Create File!");
         // write the serialized data to JSON then to the file
         file.write_all(serde_json::to_string(&self).unwrap().as_bytes())
             .expect("Failed to write json data to file");
@@ -156,8 +158,8 @@ where
     /// Imports a state from a JSON file, completely replacing any learned progress.  
     pub fn import_state_from_json(&mut self, filepath: &str) {
         // Get string from file
-        let contents =
-            std::fs::read_to_string("data/grid.json").expect("Failed to read file contents!");
+        let contents = std::fs::read_to_string("data/grid.json")
+            .expect("Failed to read file contents!");
         // initialize data container
         let mut data: HashMap<S, HashMap<S::A, f64>> = HashMap::new();
 
@@ -165,8 +167,8 @@ where
         // Else, pull everything out of the file and put it into data.
         if contents != "" {
             // deserialize from vector data
-            let vec_data: Vec<(S, Vec<(S::A, f64)>)> =
-                serde_json::from_str(&contents).expect("Failed to parse JSON File!");
+            let vec_data: Vec<(S, Vec<(S::A, f64)>)> = serde_json::from_str(&contents)
+                .expect("Failed to parse JSON File!");
             // temporary hashmap for holding inner data
             let mut inner: HashMap<S::A, f64> = HashMap::new();
             // iterate through the vector

--- a/src/mdp/mod.rs
+++ b/src/mdp/mod.rs
@@ -4,11 +4,14 @@
 
 use std::hash::Hash;
 
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 /// A `State` is something which has a reward, and has a certain set of actions associated with it.
 /// The type of the actions must be defined as the associated type `A`.
-pub trait State: Eq + Hash + Clone {
+pub trait State: Eq + Hash + Clone + Serialize + DeserializeOwned {
     /// Action type associate with this `State`.
-    type A: Eq + Hash + Clone;
+    type A: Eq + Hash + Clone + Serialize + DeserializeOwned;
 
     /// The reward for when an `Agent` arrives at this `State`.
     fn reward(&self) -> f64;


### PR DESCRIPTION
I've made some additions to rurel that will make it easy to save and load data to JSON.  In the pull request I've included examples on how to do this, and a snippet in the readme. The only catch is that serde's Serialize and Deserialize has to be derived for States and Actions in order for rurel to work. 

This does also mean we have to include serde in the toml, but I made serde `pub extern` so it can be accessed directly through rurel. End users will not have to put serde in their toml unless they want all its features. 

I'm a CS student, I'm not a professional. Just seemed like a good way to contribute to an awesome crate. 