### PR TITLE
Compute rewards from the agent due to irrelevant data

### DIFF
--- a/src/examples/eucdist.rs
+++ b/src/examples/eucdist.rs
@@ -26,12 +26,6 @@ enum MyAction {
 impl State for MyState {
     type A = MyAction;
 
-    fn reward(&self) -> f64 {
-        let (tx, ty) = (10, 10);
-        let d = (((tx - self.x).pow(2) + (ty - self.y).pow(2)) as f64).sqrt();
-        -d
-    }
-
     fn actions(&self) -> Vec<MyAction> {
         vec![
             MyAction::Move { dx: -1, dy: 0 },
@@ -44,6 +38,7 @@ impl State for MyState {
 
 struct MyAgent {
     state: MyState,
+    irrelevant_data: bool,
 }
 
 impl Agent<MyState> for MyAgent {
@@ -64,6 +59,17 @@ impl Agent<MyState> for MyAgent {
             }
         }
     }
+
+    fn reward(&self) -> f64 {
+        let (tx, ty) = (10, 10);
+        let (x, y) = (self.state.x, self.state.y);
+        let d = (((tx - x).pow(2) + (ty - y).pow(2)) as f64).sqrt();
+        if self.irrelevant_data {
+            -d
+        } else {
+            -d
+        }
+    }
 }
 
 fn main() {
@@ -76,6 +82,7 @@ fn main() {
     let mut trainer = AgentTrainer::new();
     let mut agent = MyAgent {
         state: initial_state.clone(),
+        irrelevant_data: true,
     };
     trainer.train(
         &mut agent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!     }
 //! }
 //!
-//! struct MyAgent { state: MyState }
+//! struct MyAgent { state: MyState, irrelevant_data: bool }
 //! impl Agent<MyState> for MyAgent {
 //!     fn current_state(&self) -> &MyState {
 //!         &self.state
@@ -54,6 +54,16 @@
 //!             }
 //!         }
 //!     }
+//!     fn reward(&self) -> f64 {
+//!         let (tx, ty) = (10, 10);
+//!         let (x, y) = (self.state.x, self.state.y);
+//!         let d = (((tx - x).pow(2) + (ty - y).pow(2)) as f64).sqrt();
+//!         if self.irrelevant_data {
+//!             -d
+//!         } else {
+//!             -d
+//!         }
+//!     }
 //! }
 //!
 //! use rurel::AgentTrainer;
@@ -62,7 +72,7 @@
 //! use rurel::strategy::terminate::FixedIterations;
 //!
 //! let mut trainer = AgentTrainer::new();
-//! let mut agent = MyAgent { state: MyState { x: 0, y: 0 }};
+//! let mut agent = MyAgent { state: MyState { x: 0, y: 0 }, irrelevant_data: true};
 //! trainer.train(&mut agent,
 //!               &QLearning::new(0.2, 0.01, 2.),
 //!               &mut FixedIterations::new(100000),
@@ -159,7 +169,7 @@ where
 
             // current action value
             let s_t_next = agent.current_state();
-            let r_t_next = s_t_next.reward();
+            let r_t_next = agent.reward();
 
             let v = {
                 let old_value = self.q.get(&s_t).and_then(|m| m.get(&action));

--- a/src/mdp/mod.rs
+++ b/src/mdp/mod.rs
@@ -10,8 +10,6 @@ pub trait State: Eq + Hash + Clone {
     /// Action type associate with this `State`.
     type A: Eq + Hash + Clone;
 
-    /// The reward for when an `Agent` arrives at this `State`.
-    fn reward(&self) -> f64;
     /// The set of actions that can be taken from this `State`, to arrive in another `State`.
     fn actions(&self) -> Vec<Self::A>;
     /// Selects a random action that can be taken from this `State`. The default implementation
@@ -31,6 +29,9 @@ pub trait Agent<S: State> {
     fn current_state(&self) -> &S;
     /// Takes the given action, possibly mutating the current `State`.
     fn take_action(&mut self, action: &S::A);
+    /// The reward for when an `Agent` arrives at this `State`.
+    /// The `State` during training must have relevant data so as not to distort the results. So you can add other irrelevant data on the `Agent` to calculate the rewards while keeping the right `State`.
+    fn reward(&self) -> f64;
     /// Takes a random action from the set of possible actions from this `State`. The default
     /// implementation uses [State::random_action()](trait.State.html#method.random_action) to
     /// determine the action to be taken.


### PR DESCRIPTION
The `State` during training must have relevant data so as not to distort the results. So you can add other irrelevant data on the `Agent` to calculate the rewards while keeping the right `State`.