### PR TITLE
Provide a reference to learned_values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,11 @@ where
         self.q.clone()
     }
 
+    // Returns a reference to the learned state.
+    pub fn learned_values(&self) -> &HashMap<S, HashMap<S::A, f64>> {
+        &self.q
+    }
+
     /// Imports a state, completely replacing any learned progress
     pub fn import_state(&mut self, q: HashMap<S, HashMap<S::A, f64>>) {
         self.q = q;


### PR DESCRIPTION
It can be useful to have access to the learned values without cloning them. For example, for serializating where only a reference is needed, saving the time and memory overhead of a clone.