### PR TITLE
Make iteration number more precise.

### DIFF
--- a/src/strategy/terminate/fixed_iterations.rs
+++ b/src/strategy/terminate/fixed_iterations.rs
@@ -24,6 +24,6 @@ impl FixedIterations {
 impl<S: State> TerminationStrategy<S> for FixedIterations {
     fn should_stop(&mut self, _: &S) -> bool {
         self.i += 1;
-        self.i > self.iters
+        self.i >= self.iters
     }
 }


### PR DESCRIPTION
Currently, the number of iterations passed to `FixedIterations::new` is actually 1 smaller than the number of iterations that happens because it uses `>` to check if it is done, instead of `>=`